### PR TITLE
Add sidebarLabel and pageId options

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Add it as a plugin to `docusaurus.config.js`:
 plugins: [
   ["docusaurus-plugin-openapi", {
     openapiPath: require.resolve("./openapi.json"),
+    sidebarLabel: 'summary', // summary | operationId
   }],
 ]
 ```

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ Add it as a plugin to `docusaurus.config.js`:
 plugins: [
   ["docusaurus-plugin-openapi", {
     openapiPath: require.resolve("./openapi.json"),
-    sidebarLabel: 'summary', // summary | operationId
+    sidebarLabel: "summary", // summary | operationId
+    pageId: "summary", // summary | operationId
   }],
 ]
 ```

--- a/docusaurus-plugin-openapi/src/index.ts
+++ b/docusaurus-plugin-openapi/src/index.ts
@@ -28,7 +28,8 @@ const DEFAULT_OPTIONS: PluginOptions = {
   remarkPlugins: [],
   rehypePlugins: [],
   admonitions: {},
-  sidebarLabel: "summary"
+  sidebarLabel: "summary",
+  pageId: "summary",
 };
 
 export default function pluginOpenAPI(
@@ -82,7 +83,8 @@ export default function pluginOpenAPI(
       const openapiData = await loadOpenapi(
         openapiPath,
         baseUrl,
-        routeBasePath
+        routeBasePath,
+        options
       );
 
       return { openapiData };

--- a/docusaurus-plugin-openapi/src/index.ts
+++ b/docusaurus-plugin-openapi/src/index.ts
@@ -28,6 +28,7 @@ const DEFAULT_OPTIONS: PluginOptions = {
   remarkPlugins: [],
   rehypePlugins: [],
   admonitions: {},
+  sidebarLabel: "summary"
 };
 
 export default function pluginOpenAPI(
@@ -104,7 +105,7 @@ export default function pluginOpenAPI(
           items: category.items.map((item) => {
             return {
               href: item.permalink,
-              label: item.summary,
+              label: item[options.sidebarLabel],
               type: "link",
               deprecated: item.deprecated,
             };

--- a/docusaurus-plugin-openapi/src/types.ts
+++ b/docusaurus-plugin-openapi/src/types.ts
@@ -8,6 +8,7 @@ export interface PluginOptions {
   remarkPlugins: ([Function, object] | Function)[];
   rehypePlugins: string[];
   admonitions: any;
+  sidebarLabel: "summary" | "operationId";
 }
 
 export interface LoadedContent {

--- a/docusaurus-plugin-openapi/src/types.ts
+++ b/docusaurus-plugin-openapi/src/types.ts
@@ -9,6 +9,7 @@ export interface PluginOptions {
   rehypePlugins: string[];
   admonitions: any;
   sidebarLabel: "summary" | "operationId";
+  pageId: "summary" | "operationId";
 }
 
 export interface LoadedContent {


### PR DESCRIPTION
Hello! Been playing around with this package. It's looking good so far!

I use [`operationId`](http://spec.openapis.org/oas/v3.0.3#operation-object) in all my endpoint definitions and would prefer to use them to identify the pages and as labels in the sidebar.

<img width="1423" alt="Screenshot 2020-08-05 at 22 15 50" src="https://user-images.githubusercontent.com/102141/89465008-5244cd00-d769-11ea-9b05-9911b86acb0c.png">
