### PR TITLE
Add CI/CD via GitHub Actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,27 @@
+name: Publish
+on:
+  release:
+    types: [created]
+jobs:
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+          registry-url: https://registry.npmjs.org/
+      - name: Autoincrement version
+        run: |
+          # from refs/tags/v1.2.3 get 1.2.3
+          VERSION=$(echo $GITHUB_REF | sed 's#.*/##')
+          npm version --no-git-tag-version $VERSION
+        shell: bash
+      - run: |
+          cd docusaurus-plugin-openapi
+          npm install
+          npm run build
+          npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_AUTH_TOKEN}}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,6 @@ on:
     types: [created]
 jobs:
   publish:
-    needs: build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,16 +11,17 @@ jobs:
         with:
           node-version: 12
           registry-url: https://registry.npmjs.org/
-      - name: Autoincrement version
-        run: |
-          # from refs/tags/v1.2.3 get 1.2.3
-          VERSION=$(echo $GITHUB_REF | sed 's#.*/##')
-          npm version --no-git-tag-version $VERSION
-        shell: bash
       - run: |
           cd docusaurus-plugin-openapi
+
+          # from refs/tags/v1.2.3 get 1.2.3
+          VERSION=$(echo $GITHUB_REF | sed 's#.*/##')
+          echo "Tagging version $VERSION from $GITHUB_REF"
+          npm version --no-git-tag-version $VERSION
+
           npm install
           npm run build
           npm publish
+        shell: bash
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_AUTH_TOKEN}}

--- a/docusaurus-plugin-openapi/package.json
+++ b/docusaurus-plugin-openapi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docusaurus-plugin-openapi",
-  "version": "0.0.12",
+  "version": "0.0.1",
   "description": "Docs content plugin for Docusaurus",
   "main": "lib/index.js",
   "files": [


### PR DESCRIPTION
It should publish automatically to npm upon creating a new GitHub release (using SemVer). It converts the Git Tag (`refs/tags/v1.2.3`) to `1.2.3` and updates the `package.json` only for the publish step, and does not commit the bumped version back to the repository.
