### PR TITLE
Validates ApiRequestBodyTable when attribute body.content is not defined

### DIFF
--- a/docusaurus-plugin-openapi/src/theme/ApiRequestBodyTable/index.js
+++ b/docusaurus-plugin-openapi/src/theme/ApiRequestBodyTable/index.js
@@ -139,7 +139,7 @@ function RowsRoot({ schema }) {
 }
 
 function RequestBodyTable({ body, title }) {
-  if (body === undefined) {
+  if (body === undefined || body.content === undefined) {
     return null;
   }
 


### PR DESCRIPTION
Validates ApiRequestBodyTable when attribute body.content eq undefined
Fix error of `body.content===undefined` when using ApiRequestBodyTable to display some part of ApiStatusCodeTable.

_Important: This fix asumes that body.content is either an object with at least one element or is undefined alltogether._