### PR TITLE
Update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,15 +21,10 @@ plugins: [
 ];
 ```
 
-Add it as a link in `docusaurus.config.js` to `themeConfig.navbar.links`:
+Add it as a item in `docusaurus.config.js` to `themeConfig.navbar.items`:
 
 ```js
-{
-  to: "api/",
-  activeBasePath: "api",
-  label: "API",
-  position: "left",
-}
+{ to: "/api", label: "API", position: "left" }
 ```
 
 For more than one OpenAPI definition, add them as multiple plugins to `docusaurus.config.js`:

--- a/demo/docusaurus.config.js
+++ b/demo/docusaurus.config.js
@@ -65,12 +65,7 @@ const config = {
             position: "left",
             label: "Tutorial",
           },
-          {
-            to: "api/",
-            activeBasePath: "api",
-            label: "API",
-            position: "left",
-          },
+          { to: "/api", label: "API", position: "left" },
           { to: "/blog", label: "Blog", position: "left" },
           {
             href: "https://github.com/facebook/docusaurus",


### PR DESCRIPTION
The documentation is slightly outdated since the beta release. This changes the wording from `links` to `items` and removes the unneeded `activeBasePath`.