### PR TITLE
Add sidebar item classname for method

### DIFF
--- a/packages/docusaurus-plugin-openapi/package.json
+++ b/packages/docusaurus-plugin-openapi/package.json
@@ -29,6 +29,7 @@
     "@docusaurus/utils": "^2.0.0-beta.13",
     "@docusaurus/utils-validation": "^2.0.0-beta.13",
     "chalk": "^4.1.2",
+    "clsx": "^1.1.1",
     "fs-extra": "^9.0.1",
     "js-yaml": "^4.1.0",
     "json-refs": "^3.0.15",

--- a/packages/docusaurus-plugin-openapi/src/sidebars/index.ts
+++ b/packages/docusaurus-plugin-openapi/src/sidebars/index.ts
@@ -70,6 +70,7 @@ function groupByTags(
               docId: apiPage.id,
               className: clsx({
                 "menu__list-item--deprecated": apiPage.api.deprecated,
+                "api-method": !!apiPage.api.method,
                 [apiPage.api.method]: !!apiPage.api.method,
               }),
             };
@@ -105,6 +106,7 @@ function groupByTags(
             docId: apiPage.id,
             className: clsx({
               "menu__list-item--deprecated": apiPage.api.deprecated,
+              "api-method": !!apiPage.api.method,
               [apiPage.api.method]: !!apiPage.api.method,
             }),
           };

--- a/packages/docusaurus-plugin-openapi/src/sidebars/index.ts
+++ b/packages/docusaurus-plugin-openapi/src/sidebars/index.ts
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  * ========================================================================== */
 
+import clsx from "clsx";
+
 import { ApiMetadata, ApiPageMetadata } from "../types";
 
 interface Options {
@@ -60,14 +62,16 @@ function groupByTags(
             return item.api.tags?.includes(tag);
           })
           .map((item) => {
+            const apiPage = item as ApiPageMetadata; // TODO: we should have filtered out all info pages, but I don't like this
             return {
               type: "link",
-              label: item.title,
-              href: item.permalink,
-              docId: item.id,
-              className: (item as ApiPageMetadata).api.deprecated // TODO: we should have filtered out all info pages, but I don't like this
-                ? "menu__list-item--deprecated"
-                : undefined,
+              label: apiPage.title,
+              href: apiPage.permalink,
+              docId: apiPage.id,
+              className: clsx({
+                "menu__list-item--deprecated": apiPage.api.deprecated,
+                [apiPage.api.method]: !!apiPage.api.method,
+              }),
             };
           }),
       };
@@ -93,14 +97,16 @@ function groupByTags(
           return false;
         })
         .map((item) => {
+          const apiPage = item as ApiPageMetadata; // TODO: we should have filtered out all info pages, but I don't like this
           return {
             type: "link",
-            label: item.title,
-            href: item.permalink,
-            docId: item.id,
-            className: (item as ApiPageMetadata).api.deprecated // TODO: we should have filtered out all info pages, but I don't like this
-              ? "menu__list-item--deprecated"
-              : undefined,
+            label: apiPage.title,
+            href: apiPage.permalink,
+            docId: apiPage.id,
+            className: clsx({
+              "menu__list-item--deprecated": apiPage.api.deprecated,
+              [apiPage.api.method]: !!apiPage.api.method,
+            }),
           };
         }),
     },


### PR DESCRIPTION
This PR adds addition classnames to the api sidebar items to enable support for adding method tags via css magic (thanks @sserrata):

<img width="357" alt="Screen Shot 2021-12-18 at 2 16 13 PM" src="https://user-images.githubusercontent.com/4212769/146653259-01961612-adf7-426b-9e48-df97b1dccf26.png">

CSS used to generate the above screenshot:
```css
.api-method > .menu__link {
  align-items: center;
  justify-content: start;
}

.api-method > .menu__link::before {
  width: 50px;
  height: 20px;
  font-size: 12px;
  line-height: 20px;
  text-transform: uppercase;
  font-weight: 600;
  border-radius: .25rem;
  border: 1px solid;
  margin-right: var(--ifm-spacing-horizontal);
  text-align: center;
  flex-shrink: 0;
}

.get > .menu__link::before {
  content: "get";
  border-color: var(--openapi-code-blue);
  color:  var(--openapi-code-blue);
}

.put > .menu__link::before {
  content: "put";
  border-color: var(--openapi-code-orange);
  color: var(--openapi-code-orange);
}

.post > .menu__link::before {
  content: "post";
  border-color: var(--openapi-code-green);
  color: var(--openapi-code-green);
}

.delete > .menu__link::before {
  content: "del";
  border-color: var(--openapi-code-red);
  color: var(--openapi-code-red);
}

```

closes #101 